### PR TITLE
Bump snowflake-connector from 3.0.4 to 3.15.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(name="pipelinewise-target-snowflake",
       python_requires='>=3.7',
       install_requires=[
           'pipelinewise-singer-python==1.*',
-          'snowflake-connector-python[pandas]==3.0.4',
+          'snowflake-connector-python[pandas]==3.15.0',
           'inflection==0.5.1',
           'joblib==1.2.0',
           'boto3==1.28.20',


### PR DESCRIPTION
  **Purpose:**

Receiving the error "The certificate is revoked or could not be validated" as explained in https://status.snowflake.com/incidents/txclg2cyzq32 which relates to certificate validation for external stages hosted on AWS S3.

**Changes:**

- `setup.py`: Bumping the snowflake-connector-python[pandas] to version `3.15.0`

**Testing:**

- Successfully installed the loader on Meltano `3.1.0` (currently used in production) within a Python `3.10.13` environment as `>= 3.10` is required for dependencies (`>= 3.9` for `snowflake-connector-python[pandas]==3.15.0` and `>= 3.10` for `truststore`)